### PR TITLE
Fix product ID extraction crash on MV2 pages

### DIFF
--- a/Chrome/MV2/content.js
+++ b/Chrome/MV2/content.js
@@ -172,9 +172,15 @@ async function fetchRebrickableData(productId) {
 
         if (productTitleElement && productIdElement) {
             const productIdText = productTitleElement.textContent.trim();
-            const productId = productIdText.match(/M\d+/)[0];
-            logDebug(`Product ID found: ${productId}`);
-            updateProductTitleAndImage(productTitleElement, productId);
+            const productIdMatch = productIdText.match(/M\d+/);
+            const productId = productIdMatch ? productIdMatch[0] : null;
+
+            if (productId) {
+                logDebug(`Product ID found: ${productId}`);
+                updateProductTitleAndImage(productTitleElement, productId);
+            } else {
+                logDebug('Product ID not found in title text.');
+            }
         } else {
             logDebug('Product ID or title element not found.');
         }


### PR DESCRIPTION
## Summary
- avoid crashing when no product ID is present by checking the regex match

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849a7329994832b931ac256fcf8a6c9